### PR TITLE
bug(handle): Remove _type in elasearch request

### DIFF
--- a/cmreslogging/handlers.py
+++ b/cmreslogging/handlers.py
@@ -283,7 +283,6 @@ class CMRESHandler(logging.Handler):
                 actions = (
                     {
                         '_index': self._index_name_func.__func__(self.es_index_name),
-                        '_type': self.es_doc_type,
                         '_source': log_record
                     }
                     for log_record in logs_buffer


### PR DESCRIPTION
- On elastisearch v8, they remove _type. I removed it, it worked on v8.12.1